### PR TITLE
[🔥Feat/#4] 자체로그인

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,16 @@ dependencies {
 
     // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.3'
+
+    // spring security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    testImplementation 'org.springframework.security:spring-security-test'
+
+    // jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/example/dayleaf/domain/auth/controller/AuthController.java
+++ b/src/main/java/org/example/dayleaf/domain/auth/controller/AuthController.java
@@ -1,0 +1,50 @@
+package org.example.dayleaf.domain.auth.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.example.dayleaf.domain.auth.dto.request.LoginRequest;
+import org.example.dayleaf.domain.auth.dto.request.ProfileRequest;
+import org.example.dayleaf.domain.auth.dto.request.RefreshRequest;
+import org.example.dayleaf.domain.auth.dto.request.SignUpRequest;
+import org.example.dayleaf.domain.auth.dto.response.TokenResponse;
+import org.example.dayleaf.domain.auth.service.AuthService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<TokenResponse> signUp(@RequestBody @Valid SignUpRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(authService.signUp(request));
+    }
+
+    @PostMapping("/profile")
+    public ResponseEntity<TokenResponse> completeProfile(@RequestBody @Valid ProfileRequest request) {
+        return ResponseEntity.ok(authService.completeProfile(request));
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<TokenResponse> login(@RequestBody @Valid LoginRequest request) {
+        return ResponseEntity.ok(authService.login(request));
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<TokenResponse> refresh(@RequestBody @Valid RefreshRequest request) {
+        return ResponseEntity.ok(authService.refresh(request));
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout() {
+        authService.logout();
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/org/example/dayleaf/domain/auth/dto/request/LoginRequest.java
+++ b/src/main/java/org/example/dayleaf/domain/auth/dto/request/LoginRequest.java
@@ -1,0 +1,11 @@
+package org.example.dayleaf.domain.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+        @NotBlank(message = "아이디는 필수입니다.")
+        String loginId,
+
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        String password
+) {}

--- a/src/main/java/org/example/dayleaf/domain/auth/dto/request/ProfileRequest.java
+++ b/src/main/java/org/example/dayleaf/domain/auth/dto/request/ProfileRequest.java
@@ -1,0 +1,15 @@
+package org.example.dayleaf.domain.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record ProfileRequest(
+        @NotBlank(message = "닉네임은 필수입니다.")
+        @Size(min = 2, max = 16, message = "닉네임은 2~16자 사이여야 합니다.")
+        String nickname,
+
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        String email
+) {}

--- a/src/main/java/org/example/dayleaf/domain/auth/dto/request/RefreshRequest.java
+++ b/src/main/java/org/example/dayleaf/domain/auth/dto/request/RefreshRequest.java
@@ -1,0 +1,8 @@
+package org.example.dayleaf.domain.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record RefreshRequest(
+        @NotBlank(message = "리프레시 토큰은 필수입니다.")
+        String refreshToken
+) {}

--- a/src/main/java/org/example/dayleaf/domain/auth/dto/request/SignUpRequest.java
+++ b/src/main/java/org/example/dayleaf/domain/auth/dto/request/SignUpRequest.java
@@ -1,0 +1,14 @@
+package org.example.dayleaf.domain.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record SignUpRequest(
+        @NotBlank(message = "아이디는 필수입니다.")
+        @Size(min = 4, max = 20, message = "아이디는 4~20자 사이여야 합니다.")
+        String loginId,
+
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        @Size(min = 8, max = 20, message = "비밀번호는 8~20자 사이여야 합니다.")
+        String password
+) {}

--- a/src/main/java/org/example/dayleaf/domain/auth/dto/response/TokenResponse.java
+++ b/src/main/java/org/example/dayleaf/domain/auth/dto/response/TokenResponse.java
@@ -1,0 +1,8 @@
+package org.example.dayleaf.domain.auth.dto.response;
+
+public record TokenResponse(String accessToken, String refreshToken) {
+
+    public static TokenResponse of(String accessToken, String refreshToken) {
+        return new TokenResponse(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/org/example/dayleaf/domain/auth/service/AuthService.java
+++ b/src/main/java/org/example/dayleaf/domain/auth/service/AuthService.java
@@ -1,0 +1,104 @@
+package org.example.dayleaf.domain.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.dayleaf.domain.auth.dto.request.LoginRequest;
+import org.example.dayleaf.domain.auth.dto.request.ProfileRequest;
+import org.example.dayleaf.domain.auth.dto.request.RefreshRequest;
+import org.example.dayleaf.domain.auth.dto.request.SignUpRequest;
+import org.example.dayleaf.domain.auth.dto.response.TokenResponse;
+import org.example.dayleaf.domain.member.entity.Member;
+import org.example.dayleaf.domain.member.entity.MemberRole;
+import org.example.dayleaf.domain.member.repository.MemberRepository;
+import org.example.dayleaf.global.exception.CustomException;
+import org.example.dayleaf.global.exception.ErrorCode;
+import org.example.dayleaf.global.jwt.JwtTokenProvider;
+import org.example.dayleaf.global.redis.RefreshTokenRepository;
+import org.example.dayleaf.global.security.SecurityUtils;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Transactional
+    public TokenResponse signUp(SignUpRequest request) {
+        if (memberRepository.existsByLoginId(request.loginId())) {
+            throw new CustomException(ErrorCode.LOGIN_ID_ALREADY_EXISTS);
+        }
+
+        Member member = Member.createAccount(
+                request.loginId(),
+                passwordEncoder.encode(request.password())
+        );
+        memberRepository.save(member);
+
+        return issueTokens(member);
+    }
+
+    @Transactional
+    public TokenResponse completeProfile(ProfileRequest request) {
+        Long memberId = SecurityUtils.getCurrentMemberId();
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        if (member.getRole() != MemberRole.GUEST) {
+            throw new CustomException(ErrorCode.PROFILE_ALREADY_COMPLETED);
+        }
+
+        if (memberRepository.existsByNickname(request.nickname())) {
+            throw new CustomException(ErrorCode.NICKNAME_ALREADY_EXISTS);
+        }
+
+        member.completeProfile(request.nickname(), request.email());
+
+        return issueTokens(member);
+    }
+
+    @Transactional(readOnly = true)
+    public TokenResponse login(LoginRequest request) {
+        Member member = memberRepository.findByLoginId(request.loginId())
+                .orElseThrow(() -> new CustomException(ErrorCode.INVALID_CREDENTIALS));
+
+        if (!passwordEncoder.matches(request.password(), member.getPassword())) {
+            throw new CustomException(ErrorCode.INVALID_CREDENTIALS);
+        }
+
+        return issueTokens(member);
+    }
+
+    @Transactional(readOnly = true)
+    public TokenResponse refresh(RefreshRequest request) {
+        Long memberId = jwtTokenProvider.getMemberIdFromToken(request.refreshToken());
+
+        String stored = refreshTokenRepository.find(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.INVALID_REFRESH_TOKEN));
+
+        if (!stored.equals(request.refreshToken())) {
+            throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        return issueTokens(member);
+    }
+
+    public void logout() {
+        Long memberId = SecurityUtils.getCurrentMemberId();
+        refreshTokenRepository.delete(memberId);
+    }
+
+    private TokenResponse issueTokens(Member member) {
+        String accessToken = jwtTokenProvider.createAccessToken(member.getId(), member.getRole());
+        String refreshToken = jwtTokenProvider.createRefreshToken(member.getId());
+        refreshTokenRepository.save(member.getId(), refreshToken);
+        return TokenResponse.of(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/org/example/dayleaf/domain/member/entity/Member.java
+++ b/src/main/java/org/example/dayleaf/domain/member/entity/Member.java
@@ -1,0 +1,53 @@
+package org.example.dayleaf.domain.member.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.dayleaf.global.base.BaseEntity;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 20)
+    private String loginId;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(unique = true, length = 16)
+    private String nickname;
+
+    @Column(length = 100)
+    private String email;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MemberRole role;
+
+    public static Member createAccount(String loginId, String encodedPassword) {
+        Member member = new Member();
+        member.loginId = loginId;
+        member.password = encodedPassword;
+        member.role = MemberRole.GUEST;
+        return member;
+    }
+
+    public void completeProfile(String nickname, String email) {
+        this.nickname = nickname;
+        this.email = email;
+        this.role = MemberRole.USER;
+    }
+}

--- a/src/main/java/org/example/dayleaf/domain/member/entity/MemberRole.java
+++ b/src/main/java/org/example/dayleaf/domain/member/entity/MemberRole.java
@@ -1,0 +1,5 @@
+package org.example.dayleaf.domain.member.entity;
+
+public enum MemberRole {
+    GUEST, USER
+}

--- a/src/main/java/org/example/dayleaf/domain/member/repository/MemberRepository.java
+++ b/src/main/java/org/example/dayleaf/domain/member/repository/MemberRepository.java
@@ -1,0 +1,14 @@
+package org.example.dayleaf.domain.member.repository;
+
+import java.util.Optional;
+import org.example.dayleaf.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByLoginId(String loginId);
+
+    boolean existsByLoginId(String loginId);
+
+    boolean existsByNickname(String nickname);
+}

--- a/src/main/java/org/example/dayleaf/global/config/SecurityConfig.java
+++ b/src/main/java/org/example/dayleaf/global/config/SecurityConfig.java
@@ -1,0 +1,53 @@
+package org.example.dayleaf.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.example.dayleaf.global.jwt.JwtAuthenticationFilter;
+import org.example.dayleaf.global.jwt.JwtTokenProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/api/auth/signup",
+                                "/api/auth/login",
+                                "/api/auth/refresh",
+                                "/swagger-ui/**",
+                                "/swagger-ui.html",
+                                "/v3/api-docs/**"
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(
+                        new JwtAuthenticationFilter(jwtTokenProvider),
+                        UsernamePasswordAuthenticationFilter.class
+                );
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/org/example/dayleaf/global/exception/ErrorCode.java
+++ b/src/main/java/org/example/dayleaf/global/exception/ErrorCode.java
@@ -18,10 +18,14 @@ public enum ErrorCode {
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH_002", "유효하지 않거나 만료된 토큰입니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_003", "유효하지 않은 리프레시 토큰입니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_004", "잘못된 토큰입니다."),
+    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "AUTH_005", "아이디 또는 비밀번호가 올바르지 않습니다."),
+    PROFILE_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "AUTH_006", "이미 프로필이 완성된 사용자입니다."),
 
     // ================= MEMBER =================
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_404", "사용자를 찾을 수 없습니다."),
-    MEMBER_ALREADY_EXISTS(HttpStatus.CONFLICT, "MEMBER_003", "이미 존재하는 사용자입니다.");
+    MEMBER_ALREADY_EXISTS(HttpStatus.CONFLICT, "MEMBER_003", "이미 존재하는 사용자입니다."),
+    LOGIN_ID_ALREADY_EXISTS(HttpStatus.CONFLICT, "MEMBER_001", "이미 사용 중인 아이디입니다."),
+    NICKNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "MEMBER_002", "이미 사용 중인 닉네임입니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/org/example/dayleaf/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/example/dayleaf/global/exception/GlobalExceptionHandler.java
@@ -1,8 +1,11 @@
 package org.example.dayleaf.global.exception;
 
 import jakarta.servlet.http.HttpServletRequest;
+import java.time.LocalDateTime;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -15,10 +18,30 @@ public class GlobalExceptionHandler {
             HttpServletRequest request
     ) {
         ErrorCode errorCode = e.getErrorCode();
-
         return ResponseEntity
                 .status(errorCode.getStatus())
                 .body(ErrorResponse.of(errorCode, request.getRequestURI()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidation(
+            MethodArgumentNotValidException e,
+            HttpServletRequest request
+    ) {
+        String message = e.getBindingResult().getFieldErrors().stream()
+                .map(FieldError::getDefaultMessage)
+                .findFirst()
+                .orElse(ErrorCode.INVALID_INPUT.getMessage());
+
+        return ResponseEntity
+                .badRequest()
+                .body(ErrorResponse.builder()
+                        .timestamp(LocalDateTime.now())
+                        .status(HttpStatus.BAD_REQUEST.value())
+                        .code(ErrorCode.INVALID_INPUT.getCode())
+                        .message(message)
+                        .path(request.getRequestURI())
+                        .build());
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/org/example/dayleaf/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/org/example/dayleaf/global/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,42 @@
+package org.example.dayleaf.global.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public JwtAuthenticationFilter(JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+            FilterChain filterChain) throws ServletException, IOException {
+        String token = resolveToken(request);
+
+        if (token != null && jwtTokenProvider.validateToken(token)) {
+            Authentication auth = jwtTokenProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(auth);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (StringUtils.hasText(header) && header.startsWith("Bearer ")) {
+            return header.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/example/dayleaf/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/org/example/dayleaf/global/jwt/JwtTokenProvider.java
@@ -1,0 +1,89 @@
+package org.example.dayleaf.global.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.List;
+import javax.crypto.SecretKey;
+import org.example.dayleaf.domain.member.entity.MemberRole;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtTokenProvider {
+
+    private final SecretKey key;
+    private final long accessExpiry;
+    private final long refreshExpiry;
+
+    public JwtTokenProvider(
+            @Value("${jwt.secret}") String secret,
+            @Value("${jwt.expiry}") long accessExpiry,
+            @Value("${jwt.refresh-expiry}") long refreshExpiry
+    ) {
+        this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.accessExpiry = accessExpiry;
+        this.refreshExpiry = refreshExpiry;
+    }
+
+    public String createAccessToken(Long memberId, MemberRole role) {
+        return Jwts.builder()
+                .subject(String.valueOf(memberId))
+                .claim("role", role.name())
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + accessExpiry))
+                .signWith(key)
+                .compact();
+    }
+
+    public String createRefreshToken(Long memberId) {
+        return Jwts.builder()
+                .subject(String.valueOf(memberId))
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + refreshExpiry))
+                .signWith(key)
+                .compact();
+    }
+
+    public Authentication getAuthentication(String token) {
+        Claims claims = parseClaims(token);
+        Long memberId = Long.parseLong(claims.getSubject());
+        String role = claims.get("role", String.class);
+        return new UsernamePasswordAuthenticationToken(
+                memberId,
+                token,
+                List.of(new SimpleGrantedAuthority("ROLE_" + role))
+        );
+    }
+
+    public Long getMemberIdFromToken(String token) {
+        if (!validateToken(token)) {
+            throw new org.example.dayleaf.global.exception.CustomException(
+                    org.example.dayleaf.global.exception.ErrorCode.INVALID_REFRESH_TOKEN);
+        }
+        return Long.parseLong(parseClaims(token).getSubject());
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            parseClaims(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    private Claims parseClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+}

--- a/src/main/java/org/example/dayleaf/global/redis/RefreshTokenRepository.java
+++ b/src/main/java/org/example/dayleaf/global/redis/RefreshTokenRepository.java
@@ -1,0 +1,37 @@
+package org.example.dayleaf.global.redis;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class RefreshTokenRepository {
+
+    private static final String KEY_PREFIX = "refresh:";
+
+    private final StringRedisTemplate redisTemplate;
+
+    @Value("${jwt.refresh-expiry}")
+    private long refreshExpiry;
+
+    public void save(Long memberId, String refreshToken) {
+        redisTemplate.opsForValue().set(
+                KEY_PREFIX + memberId,
+                refreshToken,
+                refreshExpiry,
+                TimeUnit.MILLISECONDS
+        );
+    }
+
+    public Optional<String> find(Long memberId) {
+        return Optional.ofNullable(redisTemplate.opsForValue().get(KEY_PREFIX + memberId));
+    }
+
+    public void delete(Long memberId) {
+        redisTemplate.delete(KEY_PREFIX + memberId);
+    }
+}

--- a/src/main/java/org/example/dayleaf/global/security/SecurityUtils.java
+++ b/src/main/java/org/example/dayleaf/global/security/SecurityUtils.java
@@ -1,0 +1,19 @@
+package org.example.dayleaf.global.security;
+
+import org.example.dayleaf.global.exception.CustomException;
+import org.example.dayleaf.global.exception.ErrorCode;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class SecurityUtils {
+
+    private SecurityUtils() {}
+
+    public static Long getCurrentMemberId() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !auth.isAuthenticated()) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+        return (Long) auth.getPrincipal();
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- #4

## 📝 Summary
### Member 엔티티

  - Member 엔티티 추가 (loginId, password, nickname, email, role)
  - MemberRole enum: GUEST / USER 2단계 권한 구분
  - 회원가입 시 GUEST로 생성, 프로필 완성 후 USER로 전환

### JWT 자체 로그인 구현

  - 회원가입 2단계
    - POST /api/auth/signup — loginId + password 입력 → GUEST 권한 토큰 발급
    - POST /api/auth/profile — nickname(중복 불가) + email 입력 → USER 권한 토큰 재발급
  - 로그인: POST /api/auth/login — loginId + password 검증 후 토큰 발급
  - Access Token payload에 memberId(subject), role 저장 → 매 요청마다 DB 조회 없이 인증
  - JwtAuthenticationFilter (OncePerRequestFilter) — Authorization 헤더에서 Bearer 토큰 추출 후 SecurityContext에 등록

### Redis Refresh Token 관리

  - POST /api/auth/refresh — Redis에 저장된 토큰과 일치 검증 후 Access/Refresh 토큰 재발급
  - POST /api/auth/logout — Redis에서 해당 유저의 Refresh Token 삭제
  - Redis 키 구조: refresh:{memberId} → refreshToken (TTL = jwt.refresh-expiry)
  - 로그인/재발급 시 기존 키를 덮어써 유저당 단일 Refresh Token 유지

### Spring Security 설정

  - CSRF disable, Stateless 세션 정책
  - permitAll: /api/auth/signup, /api/auth/login, /api/auth/refresh, Swagger 경로
  - PasswordEncoder: BCrypt 사용

### 기타

  - ErrorCode에 AUTH/MEMBER 관련 코드 추가 (INVALID_CREDENTIALS, PROFILE_ALREADY_COMPLETED, LOGIN_ID_ALREADY_EXISTS, NICKNAME_ALREADY_EXISTS)
  - GlobalExceptionHandler에 @Valid 검증 실패(MethodArgumentNotValidException) 처리 추가
  - application-local.yml: Redis localhost:6379 설정
  - application-prod.yml: REDIS_HOST, REDIS_PORT 환경변수로 주입

## 🙏 PR point

  - Refresh Token을 Redis에서 refresh:{memberId} 키로 관리해 한 기기에서 로그인 시 이전 Refresh Token이 자동 무효화됩니다. 다중 기기 지원이 필요한 경우 키 전략 변경이 필요합니다.
  - Access Token 만료 시간은 현재 local/prod 모두 2주(1209600000ms)로 맞춰두었는데, 실제 배포 전 짧게 조정이 필요합니다 (주석 처리된 1시간/3일 옵션 있음).