### PR TITLE
[✨Feat/#7] 테이블 도메인 구현

### DIFF
--- a/src/main/java/org/example/dayleaf/domain/repeat/entity/Repeat.java
+++ b/src/main/java/org/example/dayleaf/domain/repeat/entity/Repeat.java
@@ -1,0 +1,54 @@
+package org.example.dayleaf.domain.repeat.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.dayleaf.domain.node.entity.Node;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "repeat")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Repeat {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "routine_id")
+    private Integer routineId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "node_id", nullable = false)
+    private Node node;
+
+    @Column(name = "start_date", nullable = false)
+    private LocalDate startDate;
+
+    @Column(name = "end_date")
+    private LocalDate endDate;
+
+    @Column(name = "is_active", nullable = false)
+    private boolean isActive;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "repeat_type", nullable = false)
+    private RepeatType repeatType;
+
+    @Column(name = "repeat_interval", nullable = false)
+    private Integer repeatInterval;
+
+    @Column(name = "days_of_week")
+    private String daysOfWeek;
+
+    @Column(name = "day_of_month")
+    private Integer dayOfMonth;
+
+    @Column(name = "month_of_year")
+    private Integer monthOfYear;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private RepeatStatus status;
+}

--- a/src/main/java/org/example/dayleaf/domain/repeat/entity/RepeatStatus.java
+++ b/src/main/java/org/example/dayleaf/domain/repeat/entity/RepeatStatus.java
@@ -1,0 +1,7 @@
+package org.example.dayleaf.domain.repeat.entity;
+
+public enum RepeatStatus {
+    ACTIVE,
+    PAUSED,
+    ENDED
+}

--- a/src/main/java/org/example/dayleaf/domain/repeat/entity/RepeatType.java
+++ b/src/main/java/org/example/dayleaf/domain/repeat/entity/RepeatType.java
@@ -1,0 +1,8 @@
+package org.example.dayleaf.domain.repeat.entity;
+
+public enum RepeatType {
+    DAILY,
+    WEEKLY,
+    MONTHLY,
+    YEARLY
+}

--- a/src/main/java/org/example/dayleaf/domain/repeat/repository/RepeatRepository.java
+++ b/src/main/java/org/example/dayleaf/domain/repeat/repository/RepeatRepository.java
@@ -1,0 +1,7 @@
+package org.example.dayleaf.domain.repeat.repository;
+
+import org.example.dayleaf.domain.repeat.entity.Repeat;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RepeatRepository extends JpaRepository<Repeat, Integer> {
+}

--- a/src/main/java/org/example/dayleaf/domain/schedule/entity/Schedule.java
+++ b/src/main/java/org/example/dayleaf/domain/schedule/entity/Schedule.java
@@ -1,0 +1,31 @@
+package org.example.dayleaf.domain.schedule.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Schedule {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private LocalDate date;
+
+    @Column(name = "start_time", nullable = false)
+    private LocalTime startTime;
+
+    @Column(name = "end_time", nullable = false)
+    private LocalTime endTime;
+
+    @Column(name = "is_all_day", nullable = false)
+    private boolean isAllDay;
+}

--- a/src/main/java/org/example/dayleaf/domain/schedule/entity/Schedule.java
+++ b/src/main/java/org/example/dayleaf/domain/schedule/entity/Schedule.java
@@ -1,6 +1,9 @@
 package org.example.dayleaf.domain.schedule.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,13 +12,14 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 
 @Entity
+@Table(name = "schedule")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Schedule {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    @Column(name = "node_id")
+    private Long nodeId;
 
     @Column(nullable = false)
     private LocalDate date;

--- a/src/main/java/org/example/dayleaf/domain/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/org/example/dayleaf/domain/schedule/repository/ScheduleRepository.java
@@ -1,0 +1,7 @@
+package org.example.dayleaf.domain.schedule.repository;
+
+import org.example.dayleaf.domain.schedule.entity.Schedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
+}

--- a/src/main/java/org/example/dayleaf/domain/todoExcution/entity/SourceType.java
+++ b/src/main/java/org/example/dayleaf/domain/todoExcution/entity/SourceType.java
@@ -1,0 +1,7 @@
+package org.example.dayleaf.domain.todoexecution.entity;
+
+public enum SourceType {
+    MANUAL,
+    SCHEDULE,
+    REPEAT
+}

--- a/src/main/java/org/example/dayleaf/domain/todoExcution/entity/TodoExcution.java
+++ b/src/main/java/org/example/dayleaf/domain/todoExcution/entity/TodoExcution.java
@@ -1,0 +1,36 @@
+package org.example.dayleaf.domain.todoexecution.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "todo_execution")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TodoExecution {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "todo_execution_id")
+    private Long todoExecutionId;
+
+    @Column(name = "node_id", nullable = false)
+    private Long nodeId;
+
+    @Column(name = "node_id2")
+    private Long nodeId2;
+
+    @Column(nullable = false)
+    private LocalDate date;
+
+    @Column(name = "is_done", nullable = false)
+    private boolean isDone;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "source_type", nullable = false)
+    private SourceType sourceType;
+}

--- a/src/main/java/org/example/dayleaf/domain/todoExcution/repository/TodoExecutionRepository.java
+++ b/src/main/java/org/example/dayleaf/domain/todoExcution/repository/TodoExecutionRepository.java
@@ -1,0 +1,7 @@
+package org.example.dayleaf.domain.todoexecution.repository;
+
+import org.example.dayleaf.domain.todoexecution.entity.TodoExecution;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TodoExecutionRepository extends JpaRepository<TodoExecution, Long> {
+}


### PR DESCRIPTION
## 📣 Related Issue
- #7 

## 📝 Summary
- TodoExecution 엔티티 및 Repository 구현
- Schedule 엔티티 및 Repository 구현
- Repeat 엔티티 및 Repository 구현

## 🙏PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- Node 엔티티가 아직 구현되지 않아 관련 필드는 우선 Long 타입의 nodeId로 관리했습니다.
- Node 엔티티 구현 후 각 도메인의 nodeId 필드는 연관관계 매핑으로 리팩토링 예정입니다.

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
